### PR TITLE
fix: hugoの最新バージョンで動作するように"_internal/google_analytics_async.html"を使わない形に変更

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,7 +26,7 @@
 
     <!-- Only include the tracking when using `hugo` or adding `--environment production` -->
     {{ if eq hugo.Environment "production" }}
-        {{ template "_internal/google_analytics_async.html" . }}
+        {{ template "_internal/google_analytics.html" . }}
     {{ end }}
 
 </head>


### PR DESCRIPTION
https://discourse.gohugo.io/t/build-error-on-v0-125-2-calling-internal-template-internal-google-analytics-async-html/49410